### PR TITLE
fix(neoforge): used setInLoveTime in favor of setInLove

### DIFF
--- a/common/src/main/java/slexom/animal_feeding_trough/platform/common/goal/entity/ai/SelfFeedGoal.java
+++ b/common/src/main/java/slexom/animal_feeding_trough/platform/common/goal/entity/ai/SelfFeedGoal.java
@@ -64,7 +64,7 @@ public class SelfFeedGoal extends MoveToBlockGoal {
                 this.mob.getLookControl().setLookAt((double) this.blockPos.getX() + 0.5D, this.blockPos.getY(), (double) this.blockPos.getZ() + 0.5D, 10.0F, (float) this.mob.getMaxHeadXRot());
                 if (this.isReachedTarget()) {
                     this.feeder.getItems().get(0).shrink(1);
-                    this.mob.setInLove(null);
+                    this.mob.setInLoveTime(600);
                 }
             }
             this.feeder = null;


### PR DESCRIPTION
# Changes
- removed usage of setInLove in favor of setInLoveTime for 1.21.1 any other versions I recommend you doing yourself.

# Reason for change
setInLove is not needed here since passing in a null player can cause issues in forge occasionally where the animal is despawned due to a null player being passed. setInLoveTime mitigates this by removing player tracking and simply giving them a love status for x time (600 ticks by default)